### PR TITLE
Show scroll bar only when needed

### DIFF
--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -126,7 +126,7 @@
     flex-shrink: 0
   .content
     padding-top: 5px
-    overflow-y: scroll
+    overflow-y: auto
     display: flex
     flex-direction: column
     flex-grow: 1

--- a/src/components/VirtualList.svelte
+++ b/src/components/VirtualList.svelte
@@ -110,7 +110,7 @@
 <style lang="sass">
   .viewport
     height: 100%
-    overflow-y: scroll
+    overflow-y: auto
     outline: none
     background-color: inherit
   .content


### PR DESCRIPTION
First off, great client, although the scroll bar was visible for me at all times, even when I had no songs even added.
Therefore, this PR fixes that by replacing `overflow-y: scroll` with `overflow-y: auto`.

Thank you!